### PR TITLE
set max line length in black to 119 to be consistent with flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     hooks:
       - id: black
         language_version: python3.7
-
+        args: [--line-length=119]
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.7.9
     hooks:


### PR DESCRIPTION
This PR sets the max line length in black to 119, as it seems that this is the desired value according to the seeting found for flake8.